### PR TITLE
修复系统搜索与自定义新标签页扩展的冲突

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -276,7 +276,7 @@ async function handleAction(request, sender) {
 					await chrome.search.query({ text: request.query, tabId: sender.tab.id });
 				} else {
 					const newTab = await createTabAtPosition(sender, position, {
-						url: undefined,
+						url: 'about:blank',
 						active,
 						openerTabId: sender.tab.id,
 					});


### PR DESCRIPTION
## 问题

使用 FlowMouse 的文字拖拽搜索，并选择浏览器默认搜索引擎时，FlowMouse 会先创建一个 `url: undefined` 的新标签页，再调用 `chrome.search.query()`。

如果安装了 Custom New Tab URL 这类会接管新标签页的扩展，该标签页可能会先被重定向，导致拖拽搜索异常。

相关 Issue：

Fixes #71

## 修改

将：

```js
url: undefined
```

改为：

```js
url: 'about:blank'
```

这样仍然保留现有的：

* 标签页打开位置
* 前台 / 后台打开行为
* `openerTabId`

同时避免自定义新标签页扩展介入。

Firefox 分支中的对应逻辑目前也已经使用 `about:blank`。

## 测试

使用 FlowMouse 2.3 + Custom New Tab URL 进行了 A/B/A 测试：

1. `url: undefined`：可以复现冲突
2. `url: 'about:blank'`：拖拽搜索恢复正常
3. 改回 `url: undefined`：冲突再次出现

同时验证了标签页位置以及前台 / 后台打开行为没有变化。
