### PR TITLE
Add tab unload support

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -651,6 +651,30 @@
 		"message": "Scroll to Right Edge",
 		"description": "Scroll to the rightmost position"
 	},
+	"actionUnloadTab": {
+		"message": "Unload Tab",
+		"description": "Unload the current tab without closing it"
+	},
+	"closeTabsTabs": {
+		"message": "Tabs",
+		"description": "Label for regular tab handling"
+	},
+	"closeTabsPinnedTabs": {
+		"message": "Pinned tabs",
+		"description": "Label for pinned tab handling"
+	},
+	"closeTabsClose": {
+		"message": "Close",
+		"description": "Close tab handling option"
+	},
+	"closeTabsKeep": {
+		"message": "Keep",
+		"description": "Keep tab handling option"
+	},
+	"closeTabsUnload": {
+		"message": "Unload",
+		"description": "Unload tab handling option"
+	},
 	"actionCloseTab": {
 		"message": "Close Tab",
 		"description": "Close tab"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -651,6 +651,30 @@
 		"message": "滚动到最右侧",
 		"description": "Scroll to the rightmost position"
 	},
+	"actionUnloadTab": {
+		"message": "卸载标签页",
+		"description": "Unload the current tab without closing it"
+	},
+	"closeTabsTabs": {
+		"message": "标签页",
+		"description": "Label for regular tab handling"
+	},
+	"closeTabsPinnedTabs": {
+		"message": "固定标签页",
+		"description": "Label for pinned tab handling"
+	},
+	"closeTabsClose": {
+		"message": "关闭",
+		"description": "Close tab handling option"
+	},
+	"closeTabsKeep": {
+		"message": "保留",
+		"description": "Keep tab handling option"
+	},
+	"closeTabsUnload": {
+		"message": "卸载",
+		"description": "Unload tab handling option"
+	},
 	"actionCloseTab": {
 		"message": "关闭标签页",
 		"description": "Close tab"

--- a/js/background.js
+++ b/js/background.js
@@ -220,6 +220,97 @@ function replaceUrlPlaceholders(template, tab) {
 	});
 }
 
+async function unloadCurrentTab(sender, { afterClose = 'default' } = {}) {
+	const currentTab = sender.tab;
+	if (!currentTab?.id) return;
+
+	const tabs = await chrome.tabs.query({ windowId: currentTab.windowId });
+	const visibleTabs = tabs.filter(tab => tab.id !== currentTab.id && !tab.hidden);
+	const defaultTargetTabs = visibleTabs.filter(tab => !tab.discarded);
+	let targetTab;
+
+	if (afterClose === 'left') {
+		targetTab = visibleTabs
+			.filter(tab => tab.index < currentTab.index)
+			.sort((a, b) => b.index - a.index)[0]
+			|| visibleTabs.slice().sort((a, b) => b.index - a.index)[0];
+	} else if (afterClose === 'right') {
+		targetTab = visibleTabs
+			.filter(tab => tab.index > currentTab.index)
+			.sort((a, b) => a.index - b.index)[0]
+			|| visibleTabs.slice().sort((a, b) => a.index - b.index)[0];
+	} else {
+		targetTab = defaultTargetTabs
+			.filter(tab => tab.index > currentTab.index)
+			.sort((a, b) => a.index - b.index)[0];
+
+		if (!targetTab) {
+			targetTab = defaultTargetTabs
+				.filter(tab => tab.index < currentTab.index)
+				.sort((a, b) => b.index - a.index)[0];
+		}
+	}
+
+	let createdTargetTab = null;
+	if (targetTab) {
+		await chrome.tabs.update(targetTab.id, { active: true });
+	} else {
+		createdTargetTab = await chrome.tabs.create({ active: true, windowId: currentTab.windowId });
+		targetTab = createdTargetTab;
+	}
+
+	try {
+		await chrome.tabs.discard(currentTab.id);
+	} catch (error) {
+		try {
+			const sourceTab = await chrome.tabs.get(currentTab.id);
+			const [activeTab] = await chrome.tabs.query({ active: true, windowId: currentTab.windowId });
+			if (!sourceTab.discarded && activeTab?.id === targetTab?.id) {
+				await chrome.tabs.update(currentTab.id, { active: true });
+				if (createdTargetTab?.id) {
+					await chrome.tabs.remove(createdTargetTab.id).catch(() => {});
+				}
+			}
+		} catch { }
+		throw error;
+	}
+}
+
+function getPinnedTabAction(request) {
+	if (request.pinnedAction === 'close'
+		|| request.pinnedAction === 'keep'
+		|| request.pinnedAction === 'unload') {
+		return request.pinnedAction;
+	}
+	if (request.pinnedAction) return 'keep';
+	if (request.skipPinned) return 'keep';
+	if (request.preserveTab) return 'unload';
+	return 'close';
+}
+
+async function applyTabAction(tabs, action) {
+	if (action === 'keep' || tabs.length === 0) return;
+
+	if (action === 'unload') {
+		await Promise.all(tabs
+			.filter(tab => !tab.discarded)
+			.map(tab => chrome.tabs.discard(tab.id)));
+		return;
+	}
+
+	if (action === 'close') {
+		await chrome.tabs.remove(tabs.map(tab => tab.id));
+	}
+}
+
+async function applyBatchTabActions(tabs, request, regularAction) {
+	const regularTabs = tabs.filter(tab => !tab.pinned);
+	const pinnedTabs = tabs.filter(tab => tab.pinned);
+
+	await applyTabAction(regularTabs, regularAction);
+	await applyTabAction(pinnedTabs, getPinnedTabAction(request));
+}
+
 async function handleAction(request, sender) {
 	switch (request.action) {
 		case 'back':
@@ -261,9 +352,17 @@ async function handleAction(request, sender) {
 
 		case 'closeTab': {
 			if (sender.tab?.id) {
-				if (request.skipPinned && sender.tab.pinned) {
-					return { success: true };
+				if (sender.tab.pinned) {
+					const pinnedAction = getPinnedTabAction(request);
+					if (pinnedAction === 'keep') {
+						return { success: true };
+					}
+					if (pinnedAction === 'unload') {
+						await unloadCurrentTab(sender, { afterClose: request.afterClose });
+						return { success: true };
+					}
 				}
+
 				const tabs = await chrome.tabs.query({ windowId: sender.tab.windowId });
 				const currentPos = tabs.findIndex(t => t.id === sender.tab.id);
 				const afterClose = request.afterClose || 'default';
@@ -288,6 +387,10 @@ async function handleAction(request, sender) {
 			}
 			return { success: true };
 		}
+
+		case 'unloadTab':
+			await unloadCurrentTab(sender);
+			return { success: true };
 
 		case 'closeWindow':
 			if (sender.tab?.windowId) {
@@ -511,56 +614,22 @@ async function handleAction(request, sender) {
 			}
 			return { success: true };
 
-		case 'closeOtherTabs': {
-			if (sender.tab) {
-				const tabs = await chrome.tabs.query({ windowId: sender.tab.windowId });
-				const targetTabs = tabs
-					.filter(tab => tab.id !== sender.tab.id && !(request.skipPinned && tab.pinned));
-
-				if (request.preserveTab) {
-					await Promise.all(targetTabs.filter(tab => !tab.discarded).map(tab => chrome.tabs.discard(tab.id)));
-				} else {
-					const tabsToRemove = targetTabs.map(tab => tab.id);
-					if (tabsToRemove.length > 0) {
-						await chrome.tabs.remove(tabsToRemove);
-					}
-				}
-			}
-			return { success: true };
-		}
-
-		case 'closeRightTabs': {
-			if (sender.tab) {
-				const tabs = await chrome.tabs.query({ windowId: sender.tab.windowId });
-				const targetTabs = tabs
-					.filter(tab => tab.index > sender.tab.index && !(request.skipPinned && tab.pinned));
-
-				if (request.preserveTab) {
-					await Promise.all(targetTabs.filter(tab => !tab.discarded).map(tab => chrome.tabs.discard(tab.id)));
-				} else {
-					const tabsToRemove = targetTabs.map(tab => tab.id);
-					if (tabsToRemove.length > 0) {
-						await chrome.tabs.remove(tabsToRemove);
-					}
-				}
-			}
-			return { success: true };
-		}
-
+		case 'closeOtherTabs':
+		case 'closeRightTabs':
 		case 'closeLeftTabs': {
 			if (sender.tab) {
 				const tabs = await chrome.tabs.query({ windowId: sender.tab.windowId });
-				const targetTabs = tabs
-					.filter(tab => tab.index < sender.tab.index && !(request.skipPinned && tab.pinned));
+				const targetTabs = tabs.filter(tab => {
+					if (request.action === 'closeOtherTabs') return tab.id !== sender.tab.id;
+					if (request.action === 'closeRightTabs') return tab.index > sender.tab.index;
+					return tab.index < sender.tab.index;
+				});
 
-				if (request.preserveTab) {
-					await Promise.all(targetTabs.filter(tab => !tab.discarded).map(tab => chrome.tabs.discard(tab.id)));
-				} else {
-					const tabsToRemove = targetTabs.map(tab => tab.id);
-					if (tabsToRemove.length > 0) {
-						await chrome.tabs.remove(tabsToRemove);
-					}
-				}
+				await applyBatchTabActions(
+					targetTabs,
+					request,
+					request.preserveTab ? 'unload' : 'close'
+				);
 			}
 			return { success: true };
 		}
@@ -591,16 +660,14 @@ async function handleAction(request, sender) {
 
 		case 'closeAllTabs': {
 			const tabs = await chrome.tabs.query({ windowId: sender.tab.windowId });
-			const tabsToRemove = tabs
-				.filter(tab => !(request.skipPinned && tab.pinned))
-				.map(tab => tab.id);
-			if (tabsToRemove.length > 0) {
-				const remainingTabs = tabs.length - tabsToRemove.length;
-				if (remainingTabs === 0) {
-					await chrome.tabs.create({ active: true, windowId: sender.tab.windowId });
-				}
-				await chrome.tabs.remove(tabsToRemove);
+			const pinnedTabs = tabs.filter(tab => tab.pinned);
+			const pinnedAction = getPinnedTabAction(request);
+
+			if (pinnedAction !== 'keep' || pinnedTabs.length === 0) {
+				await chrome.tabs.create({ active: true, windowId: sender.tab.windowId });
 			}
+
+			await applyBatchTabActions(tabs, request, 'close');
 			return { success: true };
 		}
 

--- a/js/components/action-select.js
+++ b/js/components/action-select.js
@@ -34,6 +34,7 @@ const ACTION_ICONS = {
 	'scrollToLeftEdge': 'chevronsLeft',
 	'scrollToRightEdge': 'chevronsRight',
 	'closeTab': 'x',
+	'unloadTab': 'circlePause',
 	'closeWindow': 'squareX',
 	'closeBrowser': 'circleX',
 	'restoreTab': 'rotateCcw',
@@ -106,7 +107,7 @@ const ACTION_CATEGORIES = [
 	{ key: '', actions: ['none', 'actionChain', 'delay'] },
 	{ key: 'actionCategoryNavigation', icon: 'compass', actions: ['back', 'forward', 'urlLevelUp', 'urlToRoot', 'scrollUp', 'scrollDown', 'scrollLeft', 'scrollRight', 'scrollToTop', 'scrollToBottom', 'scrollToLeftEdge', 'scrollToRightEdge'] },
 	{ key: 'actionCategoryContextMenu', icon: 'menu', actions: ['menuShowTabs', 'menuRecentlyClosed', 'menuShowBookmarks', 'customMenu'] },
-	{ key: 'actionCategoryTabs', icon: 'panelTop', actions: ['newTab', 'closeTab', 'refresh', 'refreshAllTabs', 'switchLeftTab', 'switchRightTab', 'switchFirstTab', 'switchLastTab', 'closeOtherTabs', 'closeLeftTabs', 'closeRightTabs', 'closeAllTabs', 'switchLastActiveTab', 'restoreTab', 'duplicateTab', 'togglePinTab', 'moveTabToNewWindow'] },
+	{ key: 'actionCategoryTabs', icon: 'panelTop', actions: ['newTab', 'closeTab', 'unloadTab', 'refresh', 'refreshAllTabs', 'switchLeftTab', 'switchRightTab', 'switchFirstTab', 'switchLastTab', 'closeOtherTabs', 'closeLeftTabs', 'closeRightTabs', 'closeAllTabs', 'switchLastActiveTab', 'restoreTab', 'duplicateTab', 'togglePinTab', 'moveTabToNewWindow'] },
 	{ key: 'actionCategoryWindow', icon: 'appWindow', actions: ['newWindow', 'newIncognito', 'toggleFullscreen', 'toggleMaximize', 'minimize', 'closeWindow', 'closeBrowser'] },
 	{ key: 'actionCategoryUtilities', icon: 'wrench', actions: ['addToBookmarks', 'copyUrl', 'copyTitle', 'copyTitleAndUrl', 'openCustomUrl', 'openDownloads', 'openHistory', 'openExtensions', 'zoomIn', 'zoomOut', 'resetZoom', 'toggleMuteTab', 'toggleMuteAllTabs', 'stopLoading', 'stopAllLoading', 'printPage', 'saveAsMhtml', 'viewPageSource', 'pasteClipboard', 'pasteContent', 'searchClipboard', 'pauseGesture', 'simulateKey', 'sendCustomEvent', 'sendExtensionMessage', 'areaSelect'] },
 ];
@@ -1241,7 +1242,8 @@ class ActionSelect extends LitElement {
 			const defaults = ACTION_DEFAULTS.closeTab;
 			const keepWindowChecked = this._pendingConfig.keepWindow ?? defaults.keepWindow;
 			const afterClose = this._pendingConfig.afterClose ?? defaults.afterClose;
-			const skipPinnedChecked = this._pendingConfig.skipPinned ?? defaults.skipPinned;
+			const pinnedAction = this._pendingConfig.pinnedAction
+				|| ((this._pendingConfig.skipPinned ?? defaults.skipPinned) ? 'keep' : 'close');
 			return html`
 				<label class="action-config-checkbox">
 					<input type="checkbox"
@@ -1250,13 +1252,17 @@ class ActionSelect extends LitElement {
 					>
 					<span>${window.i18n.getMessage('closeTabKeepWindow')}</span>
 				</label>
-				<label class="action-config-checkbox">
-					<input type="checkbox"
-						.checked=${skipPinnedChecked}
-						@change=${(e) => { this._pendingConfig = { ...this._pendingConfig, skipPinned: e.target.checked }; this.requestUpdate(); }}
+				<div class="action-config-row">
+					<span class="action-config-label">${window.i18n.getMessage('closeTabsPinnedTabs')}</span>
+					<select class="action-config-select"
+						.value=${pinnedAction}
+						@change=${(e) => { this._pendingConfig = { ...this._pendingConfig, pinnedAction: e.target.value }; this.requestUpdate(); }}
 					>
-					<span>${window.i18n.getMessage('closeTabsSkipPinned')}</span>
-				</label>
+						<option value="close">${window.i18n.getMessage('closeTabsClose')}</option>
+						<option value="keep">${window.i18n.getMessage('closeTabsKeep')}</option>
+						<option value="unload">${window.i18n.getMessage('closeTabsUnload')}</option>
+					</select>
+				</div>
 				<div class="action-config-row">
 					<span class="action-config-label">${window.i18n.getMessage('closeTabAfterClose')}</span>
 					<select class="action-config-select"
@@ -1272,26 +1278,43 @@ class ActionSelect extends LitElement {
 		}
 		if (action === 'closeOtherTabs' || action === 'closeLeftTabs' || action === 'closeRightTabs' || action === 'closeAllTabs') {
 			const defaults = ACTION_DEFAULTS[action];
-			const skipPinnedChecked = this._pendingConfig.skipPinned ?? defaults.skipPinned;
 			const supportsPreserveTab = action !== 'closeAllTabs';
 			const preserveTabChecked = this._pendingConfig.preserveTab ?? defaults.preserveTab;
+			const legacyPinnedAction = (this._pendingConfig.skipPinned ?? defaults.skipPinned)
+				? 'keep'
+				: (preserveTabChecked ? 'unload' : 'close');
+			const pinnedAction = this._pendingConfig.pinnedAction || legacyPinnedAction;
 			return html`
-				<label class="action-config-checkbox">
-					<input type="checkbox"
-						.checked=${skipPinnedChecked}
-						@change=${(e) => { this._pendingConfig = { ...this._pendingConfig, skipPinned: e.target.checked }; this.requestUpdate(); }}
-					>
-					<span>${window.i18n.getMessage('closeTabsSkipPinned')}</span>
-				</label>
 				${supportsPreserveTab ? html`
-				<label class="action-config-checkbox">
-					<input type="checkbox"
-						.checked=${preserveTabChecked}
-						@change=${(e) => { this._pendingConfig = { ...this._pendingConfig, preserveTab: e.target.checked }; this.requestUpdate(); }}
+				<div class="action-config-row">
+					<span class="action-config-label">${window.i18n.getMessage('closeTabsTabs')}</span>
+					<select class="action-config-select"
+						.value=${preserveTabChecked ? 'unload' : 'close'}
+						@change=${(e) => {
+							this._pendingConfig = {
+								...this._pendingConfig,
+								preserveTab: e.target.value === 'unload',
+								pinnedAction: this._pendingConfig.pinnedAction || pinnedAction,
+							};
+							this.requestUpdate();
+						}}
 					>
-					<span>${window.i18n.getMessage('closeTabsPreserveTab')}</span>
-				</label>
+						<option value="close">${window.i18n.getMessage('closeTabsClose')}</option>
+						<option value="unload">${window.i18n.getMessage('closeTabsUnload')}</option>
+					</select>
+				</div>
 				` : ''}
+				<div class="action-config-row">
+					<span class="action-config-label">${window.i18n.getMessage('closeTabsPinnedTabs')}</span>
+					<select class="action-config-select"
+						.value=${pinnedAction}
+						@change=${(e) => { this._pendingConfig = { ...this._pendingConfig, pinnedAction: e.target.value }; this.requestUpdate(); }}
+					>
+						<option value="close">${window.i18n.getMessage('closeTabsClose')}</option>
+						<option value="keep">${window.i18n.getMessage('closeTabsKeep')}</option>
+						<option value="unload">${window.i18n.getMessage('closeTabsUnload')}</option>
+					</select>
+				</div>
 			`;
 		}
 		if (action === 'switchLeftTab' || action === 'switchRightTab') {

--- a/js/constants.js
+++ b/js/constants.js
@@ -37,6 +37,7 @@
 		'scrollToLeftEdge': 'actionScrollToLeftEdge',
 		'scrollToRightEdge': 'actionScrollToRightEdge',
 		'closeTab': 'actionCloseTab',
+		'unloadTab': 'actionUnloadTab',
 		'closeWindow': 'actionCloseWindow',
 		'closeBrowser': 'actionCloseBrowser',
 		'restoreTab': 'actionRestoreTab',
@@ -101,11 +102,11 @@
 	};
 
 	const ACTION_DEFAULTS = {
-		closeTab: { keepWindow: false, afterClose: 'default', skipPinned: false },
-		closeOtherTabs: { skipPinned: true, preserveTab: false },
-		closeLeftTabs: { skipPinned: true, preserveTab: false },
-		closeRightTabs: { skipPinned: true, preserveTab: false },
-		closeAllTabs: { skipPinned: true },
+		closeTab: { keepWindow: false, afterClose: 'default', skipPinned: false, pinnedAction: '' },
+		closeOtherTabs: { skipPinned: true, pinnedAction: '', preserveTab: false },
+		closeLeftTabs: { skipPinned: true, pinnedAction: '', preserveTab: false },
+		closeRightTabs: { skipPinned: true, pinnedAction: '', preserveTab: false },
+		closeAllTabs: { skipPinned: true, pinnedAction: '' },
 		refresh: { hardReload: false },
 		refreshAllTabs: { hardReload: false },
 		newWindow: { focused: true },

--- a/js/content.js
+++ b/js/content.js
@@ -3410,11 +3410,14 @@ window.ContentContextMenu = ContentContextMenu;
 					msg_obj.keepWindow = !!mergedConfig.keepWindow;
 					msg_obj.afterClose = mergedConfig.afterClose || 'default';
 					msg_obj.skipPinned = !!mergedConfig.skipPinned;
+					msg_obj.pinnedAction = mergedConfig.pinnedAction || '';
 				} else if (action === 'closeOtherTabs' || action === 'closeLeftTabs' || action === 'closeRightTabs') {
 					msg_obj.skipPinned = !!mergedConfig.skipPinned;
 					msg_obj.preserveTab = !!mergedConfig.preserveTab;
+					msg_obj.pinnedAction = mergedConfig.pinnedAction || '';
 				} else if (action === 'closeAllTabs') {
 					msg_obj.skipPinned = !!mergedConfig.skipPinned;
+					msg_obj.pinnedAction = mergedConfig.pinnedAction || '';
 				} else if (action === 'switchLeftTab' || action === 'switchRightTab') {
 					msg_obj.noWrap = !!mergedConfig.noWrap;
 					msg_obj.moveTab = !!mergedConfig.moveTab;


### PR DESCRIPTION
## Summary

- add a standalone `Unload Tab` action
- add pinned-tab handling options: `Close`, `Keep`, or `Unload`
- keep existing saved behavior compatible with the old `skipPinned` setting
- reuse the existing batch unload behavior and `chrome.tabs.discard()`
- avoid switching into hidden Firefox/Zen workspace tabs when unloading the current tab

## Behavior

For close actions, pinned tabs can now be handled separately:

- `Close` — close pinned tabs
- `Keep` — leave pinned tabs unchanged
- `Unload` — keep the tab but unload its page content

For batch close actions, regular tabs can still be either closed or unloaded. Existing saved behavior is preserved unless the new pinned-tab option is changed.

## Validation

Tested in Zen/Firefox with:

- standalone current-tab unload
- Close Tab with pinned tabs set to Close / Keep / Unload
- close other / left / right tabs
- hidden tabs in Zen workspaces
- unloading the only visible tab
- after-close Left / Right / Browser default behavior

The current tab is switched away before `chrome.tabs.discard()` so active-tab unloading works correctly.